### PR TITLE
Abiriadev fix replace error

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -9,7 +9,7 @@ async function getdata() {
       {
         query: `
       query getPeriodSubject($grade: Int!,$class: Int!,$day: Int!,$period: Int!) {
-        getPeriodSubject(grade: $grade,class: $class,day: $day,period: $period){
+        getPeriodSubject(grade: $grade,classNum: $class,day: $day,period: $period){
           subject
           grade
           class

--- a/backend.js
+++ b/backend.js
@@ -1,6 +1,6 @@
 import axios from "axios"
 
-const API_URL = "localhost:4000"
+const API_URL = "http://localhost:4000"
 
 async function getdata() {
   try {

--- a/token.js
+++ b/token.js
@@ -1,2 +1,0 @@
-const TOKEN = "ODY0MzA4NTkxMjU5NTQ5NzE2.YOzkGg.ERKytcS6RDbGDCtrxMvryju5zaI"
-export default TOKEN;


### PR DESCRIPTION
first, the axios error `TypeError: Cannot read property 'replace' of null` is caused when trying to pass an unreadable URL to axios.

and it was solved by passing the correct URL that `http://`localhost:4000

second, you were provide missed argument instead of `classNum`

these can find more details in commit messages.

